### PR TITLE
Fix a typo: adventureous to adventurous

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -71,7 +71,7 @@
           Each instance is hosted and moderated by different peoples across varied locations of the world, resulting in diverse rules, thematics and ambiance that it focuses on. Thus one given instance can suit you better than another, depending on your opinions and interests.
         </p>
         <p>
-          And if no existing instance makes you feel at home, you can very well <a href="https://docs.joinplu.me/installation">set up your own</a>, if you are a bit adventureous.
+          And if no existing instance makes you feel at home, you can very well <a href="https://docs.joinplu.me/installation">set up your own</a>, if you are a bit adventurous.
         </p>
         <a href="#instances">Find your dream instance</a>
       </main>


### PR DESCRIPTION
The word "adventureous" seems to be a typo of "adventurous".
