### PR TITLE
Remove inactive public instances from list

### DIFF
--- a/source/javascripts/instances.json
+++ b/source/javascripts/instances.json
@@ -16,23 +16,6 @@
       "url": "https://cafe.sunbeam.city"
     },
     {
-      "name": "plume.hostux.coffee",
-      "url": "https://plume.hostux.coffee"
-    },
-    {
-      "name": "Gospel of Celly",
-      "url": "https://gospel.sunbutt.faith"
-    },
-    {
-      "name": "blog.ksteimel.duckdns.org",
-      "url": "https://blog.ksteimel.duckdns.org"
-    },
-    {
-      "name": "DeepspaceRose.garden",
-      "description": "A small instance for writers who explore, and their curious readers",
-      "url": "https://deepspacerose.garden"
-    },
-    {
       "name": "Lorem.Club",
       "description": "A welcoming Plume instance for everyone, run by enthusiasts",
       "url": "https://lorem.club"
@@ -43,26 +26,9 @@
       "url": "https://plume.nixnet.xyz"
     },
     {
-      "name": "Write.WTF",
-      "description": "A general instance for anyone, on any topic",
-      "url": "https://write.wtf"
-    },
-    {
       "name": "Hey.dou.bet",
       "description": "Here to have a place for you. Part of the dou.bet network of decentralized services",
       "url": "https://hey.dou.bet"
-    },
-    {
-      "name": "plume.Fentanyl.Ltd",
-      "url": "https://plume.fentanyl.ltd"
-    },
-    {
-      "name": "metagnosis.xyz",
-      "url": "https://metagnosis.xyz"
-    },
-    {
-      "name": "plume.vvn.space",
-      "url": "https://plume.vvn.space"
     },
     {
       "name": "amplifi.casa",
@@ -77,27 +43,23 @@
       "description": "A Plume instance, by the OpenAlgeria team",
       "url": "https://plume.social"
     },
-    {
-      "name": "catlife.drycat.fr",
-      "url": "https://catlife.drycat.fr"
-    },
      {
-      "name": "blog.famille-link.fr",
-      "url": "https://blog.famille-link.fr"
-    },
-    {
-      "name": "Plume.Svnet.fr",
-      "description": "A Plume instance running on libre software, hosted in France",
-      "url": "https://plume.svnet.fr"
-    },
-    {
       "name": "Blog.Antopie.org",
       "description": "A Plume instance with a nice dark flair to it",
       "url": "https://blog.antopie.org"
     },
     {
-      "name": "Blog.mevo.xyz",
-      "url": "https://blog.mevo.xyz"
+      "name": "Palom.be",
+      "url": "https://palom.be"
+    },
+     {
+      "name": "bashell.com",
+      "description": "A refuge in the Fediverse",
+      "url": "https://bashell.com"
+    },
+    {
+      "name": "catlife.drycat.fr",
+      "url": "https://catlife.drycat.fr"
     }
   ]
 }


### PR DESCRIPTION
Some old links still exist but either went private, changed platforms, or are no longer active on the same domain.

Also added a couple of newly active instances.