### PR TITLE
Removal of catlife due to the upcoming closure of DryCat

### DIFF
--- a/source/javascripts/instances.json
+++ b/source/javascripts/instances.json
@@ -29,10 +29,6 @@
       "url": "https://plume.ombreport.info"
     },
     {
-      "name": "catlife.drycat.fr",
-      "url": "https://catlife.drycat.fr"
-    },
-    {
       "name": "Blog.Antopie.org",
       "description": "A Plume instance with a nice dark flair to it",
       "url": "https://blog.antopie.org"


### PR DESCRIPTION
I remove CatLife from the list of instances after the announcement of the closure of DryCat, ([article of closure](https://www.drycat.fr/fr/blog/attention-a-la-marche-en-descendant-du-train) (fr only) )

Thank you :)